### PR TITLE
Introduce consul_roles to split build process and event kick process

### DIFF
--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -29,6 +29,10 @@ namespace :stretcher do
     roles(fetch(:application_builder_roles, [:build]))
   end
 
+  def consul_roles
+    roles(fetch(:consul_roles, [:consul]))
+  end
+
   task :mark_deploying do
     set :deploying, true
   end
@@ -139,7 +143,7 @@ namespace :stretcher do
   desc "Kick the stretcher's deploy event via Consul"
   task :kick_stretcher do
     fetch(:deploy_roles).split(',').each do |target_role|
-      on application_builder_roles do
+      on consul_roles do
         opts = ["-name deploy_#{target_role}_#{fetch(:stage)}"]
         opts << "-node #{ENV['TARGET_HOSTS']}" if ENV['TARGET_HOSTS']
         opts << "#{fetch(:manifest_path)}/manifest_#{target_role}_#{fetch(:stage)}.yml"


### PR DESCRIPTION
This is to use multiple DC.

Write config:

```
server 'dc1.build.example.com', roles: %w{build consul}, no_release: true
server 'dc2.exapmle.com', roles: %w{consul}, no_release: true
```

Then, just one time build on `dc1` and distribute tgz both `dc1` and `dc2`
