### PR TITLE
Configurable gzip compression level for making tarball

### DIFF
--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -4,7 +4,7 @@ require 'yaml'
 
 namespace :load do
   task :defaults do
-    set :gzip_compression, "-9"
+    set :gzip_compress_level, "-9"
   end
 end
 
@@ -83,7 +83,7 @@ namespace :stretcher do
   task :create_tarball do
     on application_builder_roles do
       within local_build_path do
-        compress_level = fetch(:gzip_compression, "-9")
+        compress_level = fetch(:gzip_compress_level, "-9")
         execute :mkdir, '-p', "#{local_tarball_path}/#{env.now}"
         execute :tar, '-cf', '-',
           "--exclude tmp", "--exclude spec", "./",

--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -4,12 +4,13 @@ require 'yaml'
 
 namespace :load do
   task :defaults do
-    set :exclude_dirs, ["tmp"]
     set :gzip_compression, "-9"
   end
 end
 
 namespace :stretcher do
+  set :exclude_dirs, ["tmp"]
+
   def local_working_path_base
     @_local_working_path_base ||= fetch(:local_working_path_base, "/var/tmp/#{fetch :application}")
   end


### PR DESCRIPTION
When we set:

``` ruby
set :gzip_compression, "-5"
```

Then get `gzip -5` command. This may be useful for build on low power VM.
