### PR TITLE
Add requirement package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ capistrano-stretcher requires target server for building to application assets. 
  * openssl
  * aws-cli
  * consul
+ * pv
 
 target server builds assets, uploads assets to AWS S3 and invokes `consul event` automatically. So target server can access AWS s3 via aws-cli and join your deployment consul cluster.
 


### PR DESCRIPTION
`pv` is used [here](https://github.com/pepabo/capistrano-stretcher/blob/v0.3.0/lib/capistrano/tasks/stretcher.rake#L90), but `pv` is not installed by default (e.g. CentOS 7)
