### PR TITLE
Support http(s) protocol in manifest.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ capistrano-stretcher requires target server for building to application assets. 
 
 target server builds assets, uploads assets to AWS S3 and invokes `consul event` automatically. So target server can access AWS s3 via aws-cli and join your deployment consul cluster.
 
+If you want to use non-s3 (e.g. private DC), upload assets to your server with rsync and download from http(s).
+
 ## Usage
 
 You need to add `require "capistrano/stretcher"` to Capfile and add `config/deploy.rb` following variables:
@@ -55,6 +57,13 @@ set :stretcher_src, "s3://your-deployment-bucket/assets/rails-application-#{env.
 set :manifest_path, "s3://your-deployment-bucket/manifests/"
 # Optional, if you want to use mv
 set :stretcher_sync_strategy, "mv"
+
+# Optinal, if you want to http(s) in stretcher_src, manifest_path
+set :rsync_ssh_option, "-p 22"
+set :rsync_ssh_user, "MY_USER" # if undefined, use current user on build server
+set :rsync_host, "xxx.xxx.xxx.xxx"
+set :rsync_stretcher_src_path, "/var/www/resource/assets/rails-application-#{env.now}.tgz"
+set :rsync_manifest_path,      "/var/www/resource/manifests"
 ```
 
 and write hooks for stretcher to `config/stretcher.yml.erb`

--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -39,6 +39,17 @@ namespace :stretcher do
     roles(fetch(:consul_roles, [:consul]))
   end
 
+  # upload to resource server with rsync
+  def upload_resource(local_src_path, remote_dst_path)
+    rsync_ssh_command = "ssh"
+    rsync_ssh_command << " " + fetch(:rsync_ssh_option) if fetch(:rsync_ssh_option)
+    rsync_ssh_user = fetch(:rsync_ssh_user) { capture(:whoami).strip }
+
+    execute :rsync, "-ave", %Q("#{rsync_ssh_command}"),
+            local_src_path,
+            "#{rsync_ssh_user}@#{fetch(:rsync_host)}:#{remote_dst_path}"
+  end
+
   task :mark_deploying do
     set :deploying, true
   end
@@ -100,7 +111,13 @@ namespace :stretcher do
   task :upload_tarball do
     on application_builder_roles do
       as 'root' do
-        execute :aws, :s3, :cp, "#{local_tarball_path}/current/#{fetch(:local_tarball_name)}", fetch(:stretcher_src)
+        if fetch(:stretcher_src).start_with?("s3://")
+          # upload to s3
+          execute :aws, :s3, :cp, "#{local_tarball_path}/current/#{fetch(:local_tarball_name)}", fetch(:stretcher_src)
+        else
+          # upload to resource server with rsync
+          upload_resource("#{local_tarball_path}/current/#{fetch(:local_tarball_name)}", fetch(:rsync_stretcher_src_path))
+        end
       end
     end
   end
@@ -121,7 +138,15 @@ namespace :stretcher do
             t.path
           end
           upload! tempfile_path, "#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml"
-          execute :aws, :s3, :cp, "#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml", "#{fetch(:manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml"
+
+          if fetch(:manifest_path).start_with?("s3://")
+            # upload to s3
+            execute :aws, :s3, :cp, "#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml", "#{fetch(:manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml"
+          else
+            # upload to resource server with rsync
+            execute :chmod, "644", "#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml"
+            upload_resource("#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml", "#{fetch(:rsync_manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml")
+          end
         end
       end
     end

--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -39,6 +39,11 @@ namespace :stretcher do
     roles(fetch(:consul_roles, [:consul]))
   end
 
+  # upload to s3
+  def upload_s3(local_src_path, remote_dst_path)
+    execute :aws, :s3, :cp, local_src_path, remote_dst_path
+  end
+
   # upload to resource server with rsync
   def upload_resource(local_src_path, remote_dst_path)
     rsync_ssh_command = "ssh"
@@ -115,7 +120,7 @@ namespace :stretcher do
 
         if fetch(:stretcher_src).start_with?("s3://")
           # upload to s3
-          execute :aws, :s3, :cp, local_tarball_file, fetch(:stretcher_src)
+          upload_s3(local_tarball_file, fetch(:stretcher_src))
         else
           # upload to resource server with rsync
           upload_resource(local_tarball_file, fetch(:rsync_stretcher_src_path))
@@ -146,7 +151,7 @@ namespace :stretcher do
 
           if fetch(:manifest_path).start_with?("s3://")
             # upload to s3
-            execute :aws, :s3, :cp, local_manifest_file, "#{fetch(:manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml"
+            upload_s3(local_manifest_file, "#{fetch(:manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml")
           else
             # upload to resource server with rsync
             execute :chmod, "644", local_manifest_file

--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -111,12 +111,14 @@ namespace :stretcher do
   task :upload_tarball do
     on application_builder_roles do
       as 'root' do
+        local_tarball_file = "#{local_tarball_path}/current/#{fetch(:local_tarball_name)}"
+
         if fetch(:stretcher_src).start_with?("s3://")
           # upload to s3
-          execute :aws, :s3, :cp, "#{local_tarball_path}/current/#{fetch(:local_tarball_name)}", fetch(:stretcher_src)
+          execute :aws, :s3, :cp, local_tarball_file, fetch(:stretcher_src)
         else
           # upload to resource server with rsync
-          upload_resource("#{local_tarball_path}/current/#{fetch(:local_tarball_name)}", fetch(:rsync_stretcher_src_path))
+          upload_resource(local_tarball_file, fetch(:rsync_stretcher_src_path))
         end
       end
     end
@@ -137,15 +139,18 @@ namespace :stretcher do
             t.write yml
             t.path
           end
-          upload! tempfile_path, "#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml"
+
+          local_manifest_file = "#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml"
+
+          upload! tempfile_path, local_manifest_file
 
           if fetch(:manifest_path).start_with?("s3://")
             # upload to s3
-            execute :aws, :s3, :cp, "#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml", "#{fetch(:manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml"
+            execute :aws, :s3, :cp, local_manifest_file, "#{fetch(:manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml"
           else
             # upload to resource server with rsync
-            execute :chmod, "644", "#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml"
-            upload_resource("#{local_tarball_path}/current/manifest_#{role}_#{fetch(:stage)}.yml", "#{fetch(:rsync_manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml")
+            execute :chmod, "644", local_manifest_file
+            upload_resource(local_manifest_file, "#{fetch(:rsync_manifest_path)}/manifest_#{role}_#{fetch(:stage)}.yml")
           end
         end
       end


### PR DESCRIPTION
Stretcher supports s3 and http(s) in `src`, but `capistrano-stretcher` supports only s3 😿 

This feature supports http protocol.

If `:stretcher_src` (`:manifest_path` ) is not s3 path, upload to `:rsync_stretcher_src_path` (`:rsync_manifest_path`) with `rsync`
# Example
## config/deploy.rb

``` ruby
set :stretcher_src, "http://example.com/assets/rails-application-#{env.now}.tgz"
set :manifest_path, "http://example.com/manifests"
set :rsync_ssh_option, "-p 22"
set :rsync_ssh_user, "MY_USER"
set :rsync_host, "xxx.xxx.xxx.xxx"
set :rsync_stretcher_src_path, "/var/www/resource/assets/rails-application-#{env.now}.tgz"
set :rsync_manifest_path,      "/var/www/resource/manifests"
```
