### PR TITLE
set :gzip_compress_level empty (= default level)

### DIFF
--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -4,7 +4,7 @@ require 'yaml'
 
 namespace :load do
   task :defaults do
-    set :gzip_compress_level, "-9"
+    set :gzip_compress_level, ""
   end
 end
 
@@ -99,7 +99,7 @@ namespace :stretcher do
   task :create_tarball do
     on application_builder_roles do
       within local_build_path do
-        compress_level = fetch(:gzip_compress_level, "-9")
+        compress_level = fetch(:gzip_compress_level, "")
         execute :mkdir, '-p', "#{local_tarball_path}/#{env.now}"
         execute :tar, '-cf', '-',
           "--exclude tmp", "--exclude spec", "./",


### PR DESCRIPTION
Hi! Here is a benchmark compared `gzip -9` with `gzip` (set `:gzip_compress_level` empty = default compression level).
#### gzip -9

```
# build directory contains 70770 files (1.1GB)

$ time tar -cf - --exclude tmp --exclude spec ./ | pv -s $( du -sb ./ | awk '{print $1}' ) | gzip -9 > /tmp/build-benchmark.tar.gz
 935MiB 0:01:39 [9.38MiB/s] [=====================================================================================================] 103%

real    1m39.807s
user    1m41.231s
sys 0m1.955s

$ ls -hal /tmp/build-benchmark.tar.gz
-rw-rw-r--. 1 app app 545M Jun 29 17:11 /tmp/build-benchmark.tar.gz
```
#### gzip (default)

```
$ time tar -cf - --exclude tmp --exclude spec ./ | pv -s $( du -sb ./ | awk '{print $1}' ) | gzip > /tmp/build-benchmark.tar.gz
 935MiB 0:00:32 [28.3MiB/s] [=====================================================================================================] 103%

real    0m28.866s
user    0m29.663s
sys 0m2.205s

$ ls -hal /tmp/build-benchmark.tar.gz
-rw-rw-r--. 1 app app 547M Jun 29 17:13 /tmp/build-benchmark.tar.gz
```

`gzip -9` reduced about 2MB more of tar.gz than `gzip`, but it took much more real/user time (~ 60sec).

I think `gzip` (= default compression level) is effecient enough in speed and size in most situations.

If the size of tar.gz is the highest priority, you can set `:gzip_compress_level` to `-9` ( ... or any values).
