### PR TITLE
configurable gzip archiver ( Add :gzip_archiver option )

### DIFF
--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -5,6 +5,7 @@ require 'yaml'
 namespace :load do
   task :defaults do
     set :gzip_compress_level, ""
+    set :gzip_archiver, "gzip"
   end
 end
 
@@ -100,11 +101,12 @@ namespace :stretcher do
     on application_builder_roles do
       within local_build_path do
         compress_level = fetch(:gzip_compress_level, "")
+        archiver = fetch(:gzip_archiver, "gzip")
         execute :mkdir, '-p', "#{local_tarball_path}/#{env.now}"
         execute :tar, '-cf', '-',
           "--exclude tmp", "--exclude spec", "./",
           "| pv -s $( du -sb ./ | awk '{print $1}' )",
-          "| gzip #{compress_level} > #{local_tarball_path}/#{env.now}/#{fetch(:local_tarball_name)}"
+          "| #{archiver} #{compress_level} > #{local_tarball_path}/#{env.now}/#{fetch(:local_tarball_name)}"
       end
       within local_tarball_path do
         execute :rm, '-f', 'current'

--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -4,8 +4,8 @@ require 'yaml'
 
 namespace :load do
   task :defaults do
-    set :gzip_archiver_option, ""
     set :gzip_archiver, "gzip"
+    set :gzip_archiver_option, ""
   end
 end
 
@@ -100,8 +100,8 @@ namespace :stretcher do
   task :create_tarball do
     on application_builder_roles do
       within local_build_path do
-        archiver_option = fetch(:gzip_archiver_option, "")
         archiver = fetch(:gzip_archiver, "gzip")
+        archiver_option = fetch(:gzip_archiver_option, "")
         execute :mkdir, '-p', "#{local_tarball_path}/#{env.now}"
         execute :tar, '-cf', '-',
           "--exclude tmp", "--exclude spec", "./",

--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -4,7 +4,7 @@ require 'yaml'
 
 namespace :load do
   task :defaults do
-    set :gzip_compress_level, ""
+    set :gzip_archiver_option, ""
     set :gzip_archiver, "gzip"
   end
 end
@@ -100,13 +100,13 @@ namespace :stretcher do
   task :create_tarball do
     on application_builder_roles do
       within local_build_path do
-        compress_level = fetch(:gzip_compress_level, "")
+        archiver_option = fetch(:gzip_archiver_option, "")
         archiver = fetch(:gzip_archiver, "gzip")
         execute :mkdir, '-p', "#{local_tarball_path}/#{env.now}"
         execute :tar, '-cf', '-',
           "--exclude tmp", "--exclude spec", "./",
           "| pv -s $( du -sb ./ | awk '{print $1}' )",
-          "| #{archiver} #{compress_level} > #{local_tarball_path}/#{env.now}/#{fetch(:local_tarball_name)}"
+          "| #{archiver} #{archiver_option} > #{local_tarball_path}/#{env.now}/#{fetch(:local_tarball_name)}"
       end
       within local_tarball_path do
         execute :rm, '-f', 'current'


### PR DESCRIPTION
Hi. 

This pull request add `:gzip_archiver` option and you will be able to change gzip archiver ( for example: `gzip` to `pigz` ) 

Here is my benchmark comapared `gzip` wth `pigz` on EC2 with 4 processors / 7.2GB RAM.
### gzip

```
$ time tar -cf - --exclude tmp --exclude spec ./ | pv -s $( du -sb ./ | awk '{print $1}' ) | gzip > /tmp/build-benchmark.tar.gz
 935MiB 0:00:33 [27.8MiB/s] [====================================================================================================] 103%            

real    0m33.794s
user    0m35.201s
sys 0m1.910s
```
### pigz

```
$ time tar -cf - --exclude tmp --exclude spec ./ | pv -s $( du -sb ./ | awk '{print $1}' ) | pigz > /tmp/build-benchmark.tar.gz
 935MiB 0:00:13 [67.8MiB/s] [====================================================================================================] 103%            

real    0m13.901s
user    0m50.813s
sys 0m1.541s
```

On my benchmark tests, `pigz` could reduce time spent on compression than `gzip`.
