### PR TITLE
fixed NameError: uninitialized constant Tempfile

### DIFF
--- a/lib/capistrano/tasks/stretcher.rake
+++ b/lib/capistrano/tasks/stretcher.rake
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: ruby -*-
 require 'erb'
 require 'yaml'
+require 'tempfile'
 
 namespace :load do
   task :defaults do


### PR DESCRIPTION
when create manifest.yml
simple rails application deploy failed

Rails 5.1 API mode + Ruby 2.5.1

```
sshkit-1.16.0/lib/sshkit/runners/parallel.rb:15:in `rescue in block (2 levels) in execute': Exception while executing as user@hosts : uninitialized constant Tempfile (SSHKit::Runner::ExecuteError)
```